### PR TITLE
avoid using of constant REQUEST_URI

### DIFF
--- a/public/class-rebrandly-domain-redirect-public.php
+++ b/public/class-rebrandly-domain-redirect-public.php
@@ -117,7 +117,7 @@ class Rebrandly_Domain_Redirect_Public {
 			}
 			add_query_arg('rb.routing.mode', 'aliasing');
 
-			$fallback_url = "https://" . $alias . $_SERVER[REQUEST_URI];
+			$fallback_url = "https://" . $alias . $_SERVER["REQUEST_URI"];
 			$http_temporary_redirect = 302;
 			$x_redirect_by = 'rebrandly';
 			wp_redirect( $fallback_url, $http_temporary_redirect, $x_redirect_by);


### PR DESCRIPTION
newer versions of PHP would return a Warning if you use a constant like REQUEST_URI